### PR TITLE
Confirmation for single project, handle no projects

### DIFF
--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -156,11 +156,20 @@ func run(c *cli.Context) error {
 		return err
 	}
 
+	if len(projects) == 0 {
+		fmt.Printf("%s %s Your Google Cloud Platform account has no projects!\n"+
+			"Create a new GCP project at %s\n"+
+			"and refresh this window to continue deploying this application.\n",
+			errorPrefix,
+			color.New(color.FgRed, color.Bold).Sprintf("Error:"),
+			color.New(color.Bold, color.Underline).Sprint("https://console.cloud.google.com/cloud-resource-manager"),
+		)
+		return errors.New("aborting, no GCP projects available")
+	}
 	project, err := promptProject(projects)
 	if err != nil {
 		return err
 	}
-
 	end = logProgress(
 		fmt.Sprintf("Enabling Cloud Run API on project %s...", highlight(project)),
 		fmt.Sprintf("Enabled Cloud Run API on project %s.", highlight(project)),


### PR DESCRIPTION
fixes #20
fixes #22

Introduces two new modes.

1. No projects available: Send user to Cloud Console, then have them reload:
 
   ![image](https://user-images.githubusercontent.com/159209/58596513-4c7c5f00-8229-11e9-88a3-d9dc1de82576.png)

2. Single project exists: Have them confirm (default:Y , ctrl-c declines)

   ![image](https://user-images.githubusercontent.com/159209/58596532-65851000-8229-11e9-8e49-cf39fb5c9139.png)
 
cc: @steren @jamesward 