### PR TITLE
Print project count when >1

### DIFF
--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -43,8 +43,10 @@ var (
 	parameterLabel = color.New(color.FgHiCyan, color.Bold, color.Underline)
 	errorLabel     = color.New(color.FgRed, color.Bold)
 	warningLabel   = color.New(color.Bold, color.FgHiYellow)
-	successPrefix  = fmt.Sprintf("[ %s ]", color.New(color.Bold, color.FgGreen).Sprint("✓"))
+	successLabel   = color.New(color.Bold, color.FgGreen)
+	successPrefix  = fmt.Sprintf("[ %s ]", successLabel.Sprint("✓"))
 	errorPrefix    = fmt.Sprintf("[ %s ]", errorLabel.Sprint("✖"))
+	infoPrefix     = fmt.Sprintf("[ %s ]", warningLabel.Sprint("!"))
 	// we have to reset the inherited color first from survey.QuestionIcon
 	// see https://github.com/AlecAivazis/survey/issues/193
 	questionPrefix = fmt.Sprintf("%s %s ]",
@@ -172,6 +174,11 @@ func run(c *cli.Context) error {
 				"\n  3. Once you're done, press "+parameterLabel.Sprint("Enter")+" to continue: ")
 			bufio.NewReader(os.Stdin).ReadBytes('\n')
 		}
+	}
+
+	if len(projects) > 1 {
+		fmt.Printf(successPrefix+" Found %s projects in your GCP account.\n",
+			successLabel.Sprintf("%d", len(projects)))
 	}
 
 	project, err := promptProject(projects)

--- a/cmd/cloudshell_open/project.go
+++ b/cmd/cloudshell_open/project.go
@@ -94,7 +94,7 @@ func promptMultipleProjects(projects []string) (string, error) {
 
 	var p string
 	if err := survey.AskOne(&survey.Select{
-		Message: "Choose a Google Cloud Platform project to deploy:",
+		Message: "Choose a project to deploy this application:",
 		Options: projects,
 	}, &p, survey.Required); err != nil {
 		return p, fmt.Errorf("could not choose a project: %+v", err)


### PR DESCRIPTION
This helps the user understand how many projects there are available
so they can realize they can use arrow keys to move in the interactive
prompt.

Works like this: 
> ![image](https://user-images.githubusercontent.com/159209/58765293-8ea5e900-8526-11e9-8659-c4431a3a13c8.png)


Fixes #19.