### PR TITLE
Hardcode 512MiB memory for now

### DIFF
--- a/cmd/cloudshell_open/cloudrun.go
+++ b/cmd/cloudshell_open/cloudrun.go
@@ -21,12 +21,18 @@ import (
 	"unicode"
 )
 
+const (
+	defaultRunRegion = "us-central1"
+	defaultRunMemory = "512Mi"
+)
+
 func deploy(project, name, image, region string, envs []string) (string, error) {
 	cmd := exec.Command("gcloud", "beta", "run", "deploy", "-q",
 		name,
 		"--project", project,
 		"--image", image,
 		"--region", region,
+		"--memory", defaultRunMemory,
 		"--allow-unauthenticated",
 		"--set-env-vars", strings.Join(envs, ","))
 	if b, err := cmd.CombinedOutput(); err != nil {

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -34,7 +34,6 @@ const (
 	flGitBranch = "git_branch"
 	flSubDir    = "dir"
 
-	defaultRunRegion = "us-central1"
 	projectCreateURL = "https://console.cloud.google.com/cloud-resource-manager"
 )
 
@@ -263,6 +262,8 @@ func run(c *cli.Context) error {
 	cmdColor.Printf("\t --region=%s", parameter(region))
 	cmdColor.Printf(" \\\n")
 	cmdColor.Printf("\t --image=%s", parameter(image))
+	cmdColor.Printf(" \\\n")
+	cmdColor.Printf("\t --memory=%s", parameter(defaultRunMemory))
 	cmdColor.Printf(" \\\n")
 	cmdColor.Printf("\t --allow-unauthenticated\n\n")
 


### PR DESCRIPTION
Instead of offering another prompt, it's ok to hardcode this for now since most
usage will fall within the free tier. This accommodates a larger set of
applications.

Fixes #32.