### PR TITLE
hack: built image must not inherit CSR repo name

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,8 +3,8 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/button', '.']
 - name: 'gcr.io/cloudshell-images/custom-image-validation'
-  args: ['image_test.py', '--image', 'gcr.io/$PROJECT_ID/$REPO_NAME']
+  args: ['image_test.py', '--image', 'gcr.io/$PROJECT_ID/button']
 images: ['gcr.io/$PROJECT_ID/$REPO_NAME']
 timeout: '1200s'

--- a/hack/trigger-baseimage.json
+++ b/hack/trigger-baseimage.json
@@ -13,7 +13,7 @@
     },
     "timeout": "1200s",
     "images": [
-      "GCR_REPO_URL:latest"
+      "GCR_REPO_URL"
     ],
     "steps": [
       {
@@ -21,7 +21,7 @@
         "args": [
           "build",
           "-t",
-          "gcr.io/$PROJECT_ID/$REPO_NAME",
+          "GCR_REPO_URL",
           "."
         ]
       },
@@ -30,7 +30,7 @@
         "args": [
           "image_test.py",
           "--image",
-          "gcr.io/$PROJECT_ID/$REPO_NAME"
+          "GCR_REPO_URL"
         ]
       }
     ]


### PR DESCRIPTION
This doesn't work when we mirror repos from Github.