### PR TITLE
Show cmds before running, link to console

### DIFF
--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -241,11 +241,16 @@ func run(c *cli.Context) error {
 	region := defaultRunRegion
 
 	fmt.Println(infoPrefix + " Will run command:")
-	cmdColor.Printf("\tgcloud beta run deploy %s \\\n", parameter(serviceName))
-	cmdColor.Printf("\t  --project=%s \\\n", parameter(project))
-	cmdColor.Printf("\t  --region=%s \\\n", parameter(region))
-	cmdColor.Printf("\t  --image=%s \\\n", parameter(image))
-	cmdColor.Printf("\t  --memory=%s \\\n", parameter(defaultRunMemory))
+	cmdColor.Printf("\tgcloud beta run deploy %s", parameter(serviceName))
+	cmdColor.Println("\\")
+	cmdColor.Printf("\t  --project=%s", parameter(project))
+	cmdColor.Println("\\")
+	cmdColor.Printf("\t  --region=%s", parameter(region))
+	cmdColor.Println("\\")
+	cmdColor.Printf("\t  --image=%s", parameter(image))
+	cmdColor.Println("\\")
+	cmdColor.Printf("\t  --memory=%s", parameter(defaultRunMemory))
+	cmdColor.Println("\\")
 	cmdColor.Printf("\t  --allow-unauthenticated\n")
 
 	end = logProgress(fmt.Sprintf("Deploying service %s to Cloud Run...", serviceLabel),
@@ -257,15 +262,14 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf(successPrefix+" %s %s\n\n",
-		color.New(color.Bold).Sprint("Your application is now live here:\n\t"),
-		color.New(color.Bold, color.FgGreen, color.Underline).Sprint(url))
-
 	fmt.Printf("* This application is billed only when it's handling requests.\n")
 	fmt.Printf("* Manage this application at Cloud Console:\n\t")
 	color.New(color.Underline, color.Bold).Printf("https://console.cloud.google.com/run?project=%s\n", project)
 	fmt.Printf("* Learn more about Cloud Run:\n\t")
 	color.New(color.Underline, color.Bold).Println("https://cloud.google.com/run/docs")
+	fmt.Printf(successPrefix+" %s %s\n",
+		color.New(color.Bold).Sprint("Your application is now live here:\n\t"),
+		color.New(color.Bold, color.FgGreen, color.Underline).Sprint(url))
 	return nil
 }
 

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -241,12 +241,12 @@ func run(c *cli.Context) error {
 	region := defaultRunRegion
 
 	fmt.Println(infoPrefix + " Will run command:")
-	cmdColor.Printf("\tgcloud beta run deploy %s \\\n", serviceLabel)
+	cmdColor.Printf("\tgcloud beta run deploy %s \\\n", parameter(serviceName))
 	cmdColor.Printf("\t  --project=%s \\\n", parameter(project))
 	cmdColor.Printf("\t  --region=%s \\\n", parameter(region))
 	cmdColor.Printf("\t  --image=%s \\\n", parameter(image))
 	cmdColor.Printf("\t  --memory=%s \\\n", parameter(defaultRunMemory))
-	cmdColor.Printf("\t  --allow-unauthenticated\n\n")
+	cmdColor.Printf("\t  --allow-unauthenticated\n")
 
 	end = logProgress(fmt.Sprintf("Deploying service %s to Cloud Run...", serviceLabel),
 		fmt.Sprintf("Successfully deployed service %s to Cloud Run.", serviceLabel),
@@ -258,14 +258,13 @@ func run(c *cli.Context) error {
 	}
 
 	fmt.Printf(successPrefix+" %s %s\n\n",
-		color.New(color.Bold).Sprint("Your application is now live at URL:"),
+		color.New(color.Bold).Sprint("Your application is now live here:\n\t"),
 		color.New(color.Bold, color.FgGreen, color.Underline).Sprint(url))
 
-	fmt.Println("This application is billed only when it's handling requests.")
-	fmt.Printf("Manage this application at Cloud Console:\n\t")
-	color.New(color.Underline, color.Bold).Printf("https://console.cloud.google.com/run?project=%s\n\n", project)
-
-	fmt.Printf("Learn more about Cloud Run:\n\t")
+	fmt.Printf("* This application is billed only when it's handling requests.\n")
+	fmt.Printf("* Manage this application at Cloud Console:\n\t")
+	color.New(color.Underline, color.Bold).Printf("https://console.cloud.google.com/run?project=%s\n", project)
+	fmt.Printf("* Learn more about Cloud Run:\n\t")
 	color.New(color.Underline, color.Bold).Println("https://cloud.google.com/run/docs")
 	return nil
 }

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -214,7 +214,7 @@ func run(c *cli.Context) error {
 	serviceName = tryFixServiceName(serviceName)
 
 	image := fmt.Sprintf("gcr.io/%s/%s", project, serviceName)
-	fmt.Println(infoPrefix + " Will run command:")
+	fmt.Println(infoPrefix + " FYI, running the following command:")
 	cmdColor.Printf("\tdocker build -t %s %s\n", parameter(image), parameter("."))
 
 	end = logProgress(fmt.Sprintf("Building container image %s", highlight(image)),
@@ -226,7 +226,7 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println(infoPrefix + " Will run command:")
+	fmt.Println(infoPrefix + " FYI, running the following command:")
 	cmdColor.Printf("\tdocker push %s\n", parameter(image))
 	end = logProgress("Pushing container image...",
 		"Pushed container image to Google Container Registry.",
@@ -240,7 +240,7 @@ func run(c *cli.Context) error {
 	serviceLabel := highlight(serviceName)
 	region := defaultRunRegion
 
-	fmt.Println(infoPrefix + " Will run command:")
+	fmt.Println(infoPrefix + " FYI, running the following command:")
 	cmdColor.Printf("\tgcloud beta run deploy %s", parameter(serviceName))
 	cmdColor.Println("\\")
 	cmdColor.Printf("\t  --project=%s", parameter(project))


### PR DESCRIPTION
Fixes #38: We now explain app is billed only when handling requests, and we
link to Cloud Console to manage (i.e. delete) the deployed app.

Fixes #11: Verbose mode by printing the cmds before running them.