### PR TITLE
use buildpacks when Dockerfile is not present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' \
         -o /bin/a.out ./cmd/cloudshell_open
+WORKDIR /tmp
+RUN wget https://github.com/buildpack/pack/releases/download/v0.2.1/pack-v0.2.1-linux.tgz && tar -xzf pack-v0.2.1-linux.tgz
+RUN wget https://raw.githubusercontent.com/buildpack/pack/v0.2.1/LICENSE
 
 FROM gcr.io/cloudshell-images/cloudshell:latest
 RUN rm /google/devshell/bashrc.google.d/cloudshell_open.sh
 COPY --from=build /bin/a.out /bin/cloudshell_open
+COPY --from=build /tmp/pack /opt/pack/pack
+COPY --from=build /tmp/LICENSE /opt/pack/LICENSE
+RUN ln -s /opt/pack/pack /usr/local/bin/pack

--- a/cmd/cloudshell_open/docker.go
+++ b/cmd/cloudshell_open/docker.go
@@ -16,10 +16,12 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
-func build(dir, image string) error {
+func dockerBuild(dir, image string) error {
 	cmd := exec.Command("docker", "build", "--quiet", "--tag", image, dir)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
@@ -28,11 +30,22 @@ func build(dir, image string) error {
 	return nil
 }
 
-func push(image string) error {
+func dockerPush(image string) error {
 	cmd := exec.Command("docker", "push", image)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker push failed: %v, output:\n%s", err, string(b))
 	}
 	return nil
+}
+
+func dockerFileExists(dir string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(dir, "Dockerfile")); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check for Dockerfile in the repo: %v", err)
+	}
+
+	return true, nil
 }

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -214,16 +214,30 @@ func run(c *cli.Context) error {
 	serviceName = tryFixServiceName(serviceName)
 
 	image := fmt.Sprintf("gcr.io/%s/%s", project, serviceName)
-	fmt.Println(infoPrefix + " FYI, running the following command:")
-	cmdColor.Printf("\tdocker build -t %s %s\n", parameter(image), parameter("."))
 
 	end = logProgress(fmt.Sprintf("Building container image %s", highlight(image)),
 		fmt.Sprintf("Built container image %s", highlight(image)),
 		"Failed to build container image.")
-	err = build(appDir, image)
-	end(err == nil)
+
+	exists, err := dockerFileExists(appDir)
 	if err != nil {
 		return err
+	}
+
+	if exists {
+		fmt.Println(infoPrefix + " Attempting to build this application with its Dockerfile...")
+		fmt.Println(infoPrefix + " FYI, running the following command:")
+		cmdColor.Printf("\tdocker build -t %s %s\n", parameter(image), parameter("."))
+		err = dockerBuild(appDir, image)
+	} else {
+		fmt.Println(infoPrefix + " Attempting to build this application with Cloud Native Buildpacks (buildpacks.io)...")
+		fmt.Println(infoPrefix + " FYI, running the following command:")
+		cmdColor.Printf("\tpack build %s --path %s --builder heroku/buildacks\n", parameter(image), parameter(appDir))
+		err = packBuild(appDir, image)
+	}
+	end(err == nil)
+	if err != nil {
+		return fmt.Errorf("this application doesn't have a Dockerfile; attempted to build it via heroku/buildpacks and failed: %s", err)
 	}
 
 	fmt.Println(infoPrefix + " FYI, running the following command:")
@@ -231,7 +245,7 @@ func run(c *cli.Context) error {
 	end = logProgress("Pushing container image...",
 		"Pushed container image to Google Container Registry.",
 		"Failed to push container image to Google Container Registry.")
-	err = push(image)
+	err = dockerPush(image)
 	end(err == nil)
 	if err != nil {
 		return fmt.Errorf("failed to push image to %s: %+v", image, err)

--- a/cmd/cloudshell_open/pack.go
+++ b/cmd/cloudshell_open/pack.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func packBuild(dir, image string) error {
+	cmd := exec.Command("pack", "build", "--quiet", "--builder", "heroku/buildpacks", "--path", dir, image)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("pack build failed: %v, output:\n%s", err, string(b))
+	}
+	return nil
+}


### PR DESCRIPTION
This CL uses the heroku/buildpacks builder if a Dockerfile is not found.

fixes #43