### PR TITLE
appfile: accept some documentation fields

### DIFF
--- a/cmd/cloudshell_open/appfile.go
+++ b/cmd/cloudshell_open/appfile.go
@@ -36,6 +36,15 @@ type env struct {
 type appFile struct {
 	Name string         `json:"name"`
 	Env  map[string]env `json:"env"`
+
+	// The following are unused variables that are still silently accepted
+	// for compatibility with Heroku app.json files.
+
+	IgnoredDescription string   `json:"description"`
+	IgnoredKeywords    []string `json:"keywords"`
+	IgnoredLogo        string   `json:"logo"`
+	IgnoredRepository  string   `json:"repository"`
+	IgnoredWebsite     string   `json:"website"`
 }
 
 const appJSON = `app.json`

--- a/cmd/cloudshell_open/appfile_test.go
+++ b/cmd/cloudshell_open/appfile_test.go
@@ -149,6 +149,20 @@ func Test_parseAppFile(t *testing.T) {
 	}
 }
 
+func Test_parseAppFile_parsesIgnoredKnownFields(t *testing.T) {
+	appFile := `{
+		"description": "String",
+		"repository": "URL",
+		"logo": "URL",
+		"website": "URL",
+		"keywords": ["String", "String"]
+	}`
+	_, err := parseAppFile(strings.NewReader(appFile))
+	if err != nil {
+		t.Fatalf("app.json with ignored but known fields failed: %v", err)
+	}
+}
+
 func TestGetAppFile(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "app.json-test")
 	if err != nil {


### PR DESCRIPTION
Accepting and ignoring some documentation fields that have no functional
impact from Heroku app.json to be more forgiving for portability.

Fixes #53.
@jamesward