### PR TITLE
bump to pack 0.3.0 - fixes #56

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' \
         -o /bin/a.out ./cmd/cloudshell_open
 WORKDIR /tmp
-RUN wget https://github.com/buildpack/pack/releases/download/v0.2.1/pack-v0.2.1-linux.tgz
-RUN tar -xzf pack-v0.2.1-linux.tgz
-RUN wget https://raw.githubusercontent.com/buildpack/pack/v0.2.1/LICENSE
+RUN wget https://github.com/buildpack/pack/releases/download/v0.3.0/pack-v0.3.0-linux.tgz
+RUN tar -xzf pack-v0.3.0-linux.tgz
+RUN wget https://raw.githubusercontent.com/buildpack/pack/v0.3.0/LICENSE
 
 FROM gcr.io/cloudshell-images/cloudshell:latest
 RUN rm /google/devshell/bashrc.google.d/cloudshell_open.sh


### PR DESCRIPTION
Manually validated with `--repo_url=https://github.com/jamesward/hello-go.git --git_branch=buildpack`