### PR TITLE
Correct spelling on replication command

### DIFF
--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -233,7 +233,7 @@ func run(c *cli.Context) error {
 	} else {
 		fmt.Println(infoPrefix + " Attempting to build this application with Cloud Native Buildpacks (buildpacks.io)...")
 		fmt.Println(infoPrefix + " FYI, running the following command:")
-		cmdColor.Printf("\tpack build %s --path %s --builder heroku/buildacks\n", parameter(image), parameter(appDir))
+		cmdColor.Printf("\tpack build %s --path %s --builder heroku/buildpacks\n", parameter(image), parameter(appDir))
 	}
 
 	end = logProgress(fmt.Sprintf("Building container image %s", highlight(image)),


### PR DESCRIPTION
I don't believe this is a bug, just if a user tries to copy the sample command they will encounter issues due to the misspelling