### PR TITLE
cmd/redirector: Auto-redirect based on Referer

### DIFF
--- a/cmd/redirector/Dockerfile
+++ b/cmd/redirector/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1-alpine AS build
+RUN apk add --no-cache git
+WORKDIR /src/app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /server -ldflags="-w -s" . # rundev
+
+FROM scratch
+COPY --from=build /server /server
+ENTRYPOINT ["/server"]

--- a/cmd/redirector/extractors.go
+++ b/cmd/redirector/extractors.go
@@ -1,0 +1,18 @@
+package main
+
+import "net/url"
+
+type repoRef interface {
+	GitURL() string
+	Dir() string
+	Ref() string
+}
+
+var (
+	availableExtractors = map[string]extractor{
+		"github.com": extractGitHubURL,
+		"gitlab.com": extractGitLabURL,
+	}
+)
+
+type extractor func(*url.URL) (repoRef, error)

--- a/cmd/redirector/github.go
+++ b/cmd/redirector/github.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type gitHubRepoRef struct {
+	user string
+	repo string
+	ref  string
+	dir  string
+}
+
+func (g gitHubRepoRef) GitURL() string { return "https://github.com/" + g.user + "/" + g.repo + ".git" }
+func (g gitHubRepoRef) Dir() string    { return g.dir }
+func (g gitHubRepoRef) Ref() string    { return g.ref }
+
+var (
+	// ghSubpages matches tree/REF[/SUBPATH] or blob/REF/SUBPATH paths on GitHub.
+	ghSubpages = regexp.MustCompile(`(?U)^(tree|blob)\/(.*)?(\/.*)?$`)
+)
+
+func extractGitHubURL(u *url.URL) (repoRef, error) {
+	var rr gitHubRepoRef
+	path := cleanupPath(u.Path)
+	parts := strings.SplitN(path, "/", 3)
+
+	if len(parts) < 2 {
+		return rr, errors.New("url is not sufficient to infer the repository name")
+	}
+	rr.user, rr.repo = parts[0], parts[1]
+
+	if len(parts)>2 {
+		subPath := parts[2]
+		group := ghSubpages.FindStringSubmatch(subPath)
+		if len(group) == 0 {
+			return rr, errors.New("only tree/ and blob/ urls on the repositories are supported")
+		}
+		if group[2] != "" {
+			rr.ref = group[2]
+		}
+		rr.dir = strings.TrimLeft(group[3], "/")
+	}
+	return rr, nil
+}
+
+// cleanupPath removes the leading or trailing slashes, or the README.md from the path.
+func cleanupPath(path string) string {
+	path = strings.TrimSuffix(path, "README.md")
+	path = strings.Trim(path, "/")
+	return path
+}

--- a/cmd/redirector/github_test.go
+++ b/cmd/redirector/github_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func Test_cleanupPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "empty",
+			path: "",
+			want: "",
+		},
+		{
+			name: "root",
+			path: "/",
+			want: "",
+		},
+		{
+			name: "slashes",
+			path: "/user/repo/tree/master/",
+			want: "user/repo/tree/master",
+		},
+		{
+			name: "readme.md trimming",
+			path: "/path/README.md",
+			want: "path",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanupPath(tt.path); got != tt.want {
+				t.Errorf("cleanupPath(%s) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractGitHubURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    gitHubRepoRef
+		wantErr bool
+	}{
+		{
+			name:    "insufficient parts",
+			url:     "https://github.com",
+			wantErr: true,
+		},
+		{
+			name:    "insufficient parts only username",
+			url:     "https://github.com/google",
+			wantErr: true,
+		},
+		{
+			name: "repository home",
+			url:  "https://github.com/google/new-project",
+			want: gitHubRepoRef{
+				user: "google",
+				repo: "new-project",
+			},
+		},
+		{
+			name:    "unsupported repository subpath",
+			url:     "https://github.com/google/new-project/commits/master",
+			wantErr: true,
+		},
+		{
+			name: "repository tree with ref",
+			url:  "https://github.com/google/new-project/tree/master",
+			want: gitHubRepoRef{
+				user: "google",
+				repo: "new-project",
+				ref:  "master",
+			},
+		},
+		{
+			name: "repository tree sub-dir README",
+			url:  "https://github.com/google/new-project/tree/v1/sub/dir/README.md",
+			want: gitHubRepoRef{
+				user: "google",
+				repo: "new-project",
+				ref:  "v1",
+				dir:  "sub/dir",
+			},
+		},
+		{
+			name: "repository blob root README",
+			url:  "https://github.com/google/new-project/blob/v1/README.md",
+			want: gitHubRepoRef{
+				user: "google",
+				repo: "new-project",
+				ref:  "v1",
+			},
+		},
+		{
+			name: "repository blob sub-dir README",
+			url:  "https://github.com/google/new-project/blob/v1/sub/dir/README.md",
+			want: gitHubRepoRef{
+				user: "google",
+				repo: "new-project",
+				ref:  "v1",
+				dir:  "sub/dir",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractGitHubURL(mustURL(t, tt.url))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractGitHubURL(%s) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractGitHubURL(%s) got = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func mustURL(t *testing.T, u string) *url.URL {
+	t.Helper()
+	v, err := url.Parse(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}

--- a/cmd/redirector/gitlab.go
+++ b/cmd/redirector/gitlab.go
@@ -1,0 +1,3 @@
+package main
+
+var extractGitLabURL = extractGitHubURL // as they currently use the same URL schema

--- a/cmd/redirector/gitlab_test.go
+++ b/cmd/redirector/gitlab_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractGitLabURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    gitHubRepoRef
+		wantErr bool
+	}{
+		{
+			name:    "insufficient parts",
+			in:      "https://gitlab.com",
+			wantErr: true,
+		},
+		{
+			name:    "insufficient parts only username",
+			in:      "https://gitlab.com/gitlab-org",
+			wantErr: true,
+		},
+		{
+			name: "repository home",
+			in:   "https://gitlab.com/gitlab-org/gitlab-runner",
+			want: gitHubRepoRef{
+				user: "gitlab-org",
+				repo: "gitlab-runner",
+			},
+		},
+		{
+			name: "unsupported repo subpath",
+			in:   "https://gitlab.com/gitlab-org/gitlab-runner/commits/master",
+			wantErr: true,
+		},
+		{
+			name: "repository tree with ref",
+			in:   "https://gitlab.com/gitlab-org/gitlab-runner/tree/master",
+			want: gitHubRepoRef{
+				user: "google",
+				repo: "gitlab-runner",
+				ref:  "master",
+			},
+		},
+		{
+			name: "repository tree sub-dir README",
+			in:   "https://gitlab.com/gitlab-org/gitlab-runner/tree/v1/sub/dir/README.md",
+			want: gitHubRepoRef{
+				user: "gitlab-org",
+				repo: "gitlab-runner",
+				ref:  "v1",
+				dir:  "sub/dir",
+			},
+		},
+		{
+			name: "repository blob root README",
+			in:   "https://gitlab.com/gitlab-org/gitlab-runner/blob/v1/README.md",
+			want: gitHubRepoRef{
+				user: "gitlab-org",
+				repo: "gitlab-runner",
+				ref:  "v1",
+			},
+		},
+		{
+			name: "repository blob sub-dir README",
+			in:   "https://gitlab.com/gitlab-org/gitlab-runner/blob/v1/sub/dir/README.md",
+			want: gitHubRepoRef{
+				user: "gitlab-org",
+				repo: "gitlab-runner",
+				ref:  "v1",
+				dir:  "sub/dir",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractGitLabURL(mustURL(t, tt.in))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractGitLabURL(%s) error = %v, wantErr %v", tt.in, err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractGitLabURL(%s) got = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/redirector/go.mod
+++ b/cmd/redirector/go.mod
@@ -1,0 +1,5 @@
+module redirector
+
+go 1.12
+
+require github.com/pkg/errors v0.8.1

--- a/cmd/redirector/go.sum
+++ b/cmd/redirector/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/cmd/redirector/main.go
+++ b/cmd/redirector/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"log"
+	"net/http"
+	"os"
+)
+
+const (
+	hdrReferer = "Referer"
+)
+
+func main() {
+	log.SetFlags(log.Lmicroseconds)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	listenAddr := ":" + port
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", withLogging(redirect))
+
+	err := http.ListenAndServe(listenAddr, mux)
+	if err == http.ErrServerClosed {
+		log.Printf("server successfully closed")
+	} else if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func withLogging(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		log.Printf("request: method=%s ip=%s referer=%s params=%s", req.Method, req.RemoteAddr, req.Header.Get(hdrReferer), req.URL.RawQuery)
+		ww := &respRecorder{w: w}
+		next(ww, req)
+		log.Printf("response: status=%d location=%s", ww.status, w.Header().Get("location"))
+	}
+}
+
+func redirect(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprintf(w, "method %s not allowed", req.Method)
+		return
+	}
+
+	repoParam := req.URL.Query().Get(paramRepo)
+	referer := req.Header.Get(hdrReferer)
+
+	var repo repoRef
+	if repoParam != "" {
+		repo = customRepoRef{req.URL.Query()}
+	} else {
+		if referer == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "Cannot infer which repository to deploy (%s header was not present).\n", hdrReferer)
+			fmt.Fprintln(w, "Go back, and click the 'Run on Google Cloud' button directly from the repository page.")
+			return
+		}
+		r, err := parseReferer(referer, availableExtractors)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, errors.Wrapf(err, "failed to parse %s header", hdrReferer).Error())
+			return
+		}
+		repo = r
+	}
+
+	target := prepURL(repo, req.URL.Query())
+	w.Header().Set("location", target)
+	w.WriteHeader(http.StatusTemporaryRedirect)
+}
+
+type respRecorder struct {
+	w      http.ResponseWriter
+	status int
+}
+
+func (rr *respRecorder) Header() http.Header         { return rr.w.Header() }
+func (rr *respRecorder) Write(p []byte) (int, error) { return rr.w.Write(p) }
+func (rr *respRecorder) WriteHeader(statusCode int) {
+	rr.status = statusCode
+	rr.w.WriteHeader(statusCode)
+}

--- a/cmd/redirector/main_test.go
+++ b/cmd/redirector/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestRedirect_unsupportedMethods(t *testing.T) {
+	methods := []string{"PUT", "POST", "DELETE", "OPTIONS", "UNKNOWN"}
+	for _, m := range methods {
+		req := httptest.NewRequest(m, "/", nil)
+
+		rr := httptest.NewRecorder()
+		redirect(rr, req)
+
+		if got, expected := rr.Code, http.StatusMethodNotAllowed; got != expected {
+			t.Fatalf("for method=%s got=%d expected=%d", m, got, expected)
+		}
+	}
+}
+
+func TestRedirect_missingReferer(t *testing.T) {
+	req := httptest.NewRequest("", "/", nil)
+	rr := httptest.NewRecorder()
+	redirect(rr, req)
+	if expected, status := http.StatusBadRequest, rr.Code; expected != status {
+		t.Fatalf("status: got=%d expected=%d", status, expected)
+	}
+}
+
+func TestRedirect_referer(t *testing.T) {
+	repo := "https://github.com/google/new-project"
+	req := httptest.NewRequest("", "/", nil)
+	req.Header.Set("Referer", repo)
+
+	rr := httptest.NewRecorder()
+	redirect(rr, req)
+
+	if expected, status := http.StatusTemporaryRedirect, rr.Code; expected != status {
+		t.Fatalf("status: got=%d expected=%d", status, expected)
+	}
+
+	loc := rr.Header().Get("location")
+	s := "cloudshell_git_repo=" + url.QueryEscape(repo+".git")
+	if !strings.Contains(loc, s) {
+		t.Fatalf("location header doesn't contain %s\nurl='%s'", s, loc)
+	}
+}
+
+func TestRedirect_referer_passthrough(t *testing.T) {
+	repo := "https://github.com/google/new-project"
+	req := httptest.NewRequest("", "/?cloudshell_xxx=yyy", nil)
+	req.Header.Set("Referer", repo)
+
+	rr := httptest.NewRecorder()
+	redirect(rr, req)
+
+	loc := rr.Header().Get("location")
+	s := "cloudshell_xxx=yyy"
+	if !strings.Contains(loc, s) {
+		t.Fatalf("location header doesn't contain %s\nurl='%s'", s, loc)
+	}
+}
+
+func TestRedirect_unknownReferer(t *testing.T) {
+	req := httptest.NewRequest("", "/", nil)
+	req.Header.Set("Referer", "http://example.com")
+
+	rr := httptest.NewRecorder()
+	redirect(rr, req)
+
+	if expected, status := http.StatusBadRequest, rr.Code; expected != status {
+		t.Fatalf("status: got=%d expected=%d", status, expected)
+	}
+}
+
+func TestRedirect_queryParams(t *testing.T) {
+	req := httptest.NewRequest("", "/?git_repo=foo&dir=bar&revision=staging", nil)
+	req.Header.Set("Referer", "http://example.com")
+
+	rr := httptest.NewRecorder()
+	redirect(rr, req)
+	if expected, status := http.StatusTemporaryRedirect, rr.Code; expected != status {
+		t.Fatalf("status: got=%d expected=%d", status, expected)
+	}
+
+	loc := rr.Header().Get("location")
+	fragments := []string{"cloudshell_git_repo=foo", "cloudshell_working_dir=bar", "cloudshell_git_branch=staging"}
+	for _, s := range fragments {
+		if !strings.Contains(loc, s) {
+			t.Fatalf("location header doesn't contain fragment:%s\nurl='%s'", s, loc)
+		}
+	}
+}

--- a/cmd/redirector/referer.go
+++ b/cmd/redirector/referer.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"net/url"
+	"strings"
+)
+
+const (
+	paramDir  = "dir"
+	paramRev  = "revision"
+	paramRepo = "git_repo"
+)
+
+func parseReferer(v string, extractors map[string]extractor) (repoRef, error) {
+	u, err := url.Parse(v)
+	if err != nil {
+		return nil, errors.Errorf("could not parse %s as url", v)
+	}
+	fn, ok := extractors[u.Hostname()]
+	if !ok {
+		return nil, errors.Errorf("hostname %s not supported", u.Hostname())
+	}
+
+	out, err := fn(u)
+	return out, errors.Wrap(err, "failed to extract URL components")
+}
+
+func prepURL(r repoRef, overrides url.Values) string {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   "console.cloud.google.com",
+		Path:   "cloudshell/editor",
+	}
+	q := make(url.Values)
+	q.Set("cloudshell_image", "gcr.io/cloudrun/button")
+	q.Set("cloudshell_git_repo", r.GitURL())
+	if v := r.Ref(); v != "" {
+		q.Set("cloudshell_git_branch", v)
+	}
+	if v := r.Dir(); v != "" {
+		q.Set("cloudshell_working_dir", v)
+	}
+
+	// overrides
+	if v := overrides.Get(paramRepo); v != "" {
+		q.Set("cloudshell_git_repo", v)
+	}
+	if v := overrides.Get(paramDir); v != "" {
+		q.Set("cloudshell_working_dir", v)
+	}
+	if v := overrides.Get(paramRev); v != "" {
+		q.Set("cloudshell_git_branch", v)
+	}
+
+	// pass-through query parameters
+	for k := range overrides {
+		if strings.HasPrefix(k, "cloudshell_") {
+			q.Set(k, overrides.Get(k))
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+type customRepoRef struct{ v url.Values }
+
+func (c customRepoRef) GitURL() string { return c.v.Get(paramRepo) }
+func (c customRepoRef) Dir() string    { return c.v.Get(paramDir) }
+func (c customRepoRef) Ref() string    { return c.v.Get(paramRev) }

--- a/cmd/redirector/referer_test.go
+++ b/cmd/redirector/referer_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+)
+
+type mockRepo struct{ dir, ref string }
+
+func (m mockRepo) GitURL() string { return "GIT" }
+
+func (m mockRepo) Dir() string { return m.dir }
+
+func (m mockRepo) Ref() string { return m.ref }
+
+func Test_prepURL(t *testing.T) {
+	type args struct {
+		r         repoRef
+		overrides url.Values
+	}
+	tests := []struct {
+		name string
+		args args
+		want string // TODO(ahmetb): tests may break because on every new go version go map iteration seeds change, and query parameters will shuffle
+	}{
+		{
+			name: "bare repo",
+			args: args{
+				r:         mockRepo{},
+				overrides: nil,
+			},
+			want: "https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=GIT&cloudshell_image=gcr.io%2Fcloudrun%2Fbutton",
+		},
+		{
+			name: " repo with dir",
+			args: args{
+				r:         mockRepo{dir: "foo"},
+				overrides: nil,
+			},
+			want: "https://console.cloud.google.com/cloudshell/editor?cloudshell_working_dir=foo&cloudshell_git_repo=GIT&cloudshell_image=gcr.io%2Fcloudrun%2Fbutton",
+		},
+		{
+			name: "repo with ref",
+			args: args{
+				r:         mockRepo{ref: "bar"},
+				overrides: nil,
+			},
+			want: "https://console.cloud.google.com/cloudshell/editor?cloudshell_working_dir=bar&cloudshell_git_repo=GIT&cloudshell_image=gcr.io%2Fcloudrun%2Fbutton",
+		},
+		{
+			name: "passthrough flags",
+			args: args{
+				r:         mockRepo{},
+				overrides: url.Values{
+					"cloudshell_xxx":[]string{"yyy"},
+				},
+			},
+			want: "https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=GIT&cloudshell_image=gcr.io%2Fcloudrun%2Fbutton&cloudshell_xxx=yyy",
+		},
+		{
+			name: "passthrough flags as override",
+			args: args{
+				r:         mockRepo{},
+				overrides: url.Values{
+					"cloudshell_git_repo":[]string{"FOO"},
+				},
+			},
+			want: "https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=FOO&cloudshell_image=gcr.io%2Fcloudrun%2Fbutton",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prepURL(tt.args.r, tt.args.overrides); got != tt.want {
+				t.Errorf("prepURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This server redirects requests to Cloud Shell from GitHub and GitLab pages.

Currently supported schemas:
- repository home page
- tree/REF(/PATH)
- blob/REF/PATH
- README.md suffix in the URLs also trimmed so the sub directory can be
  determined properly.

This currently supports:

- complete detection of repo/rev/dir from Referer header
- if ?git_repo is specified, Referer is optional (?git_repo takes precedence)
- users can also override git ref & sub-dir with ?revision= and ?dir= params
- any ?cloudshell_* param is also accepted (as passthrough/override)