### PR TITLE
cmd/redirector: fix tests

### DIFF
--- a/cmd/redirector/gitlab_test.go
+++ b/cmd/redirector/gitlab_test.go
@@ -39,7 +39,7 @@ func TestExtractGitLabURL(t *testing.T) {
 			name: "repository tree with ref",
 			in:   "https://gitlab.com/gitlab-org/gitlab-runner/tree/master",
 			want: gitHubRepoRef{
-				user: "google",
+				user: "gitlab-org",
 				repo: "gitlab-runner",
 				ref:  "master",
 			},


### PR DESCRIPTION
- fix gitlab_test.go

- fix prepURL() tests as they were previously susceptible to Go version
  changes (and therefore query params rendered to url in a different order
  than the expected value hardcoded in test)