### PR TITLE
Wait for credentials to be present

### DIFF
--- a/cmd/redirector/main.go
+++ b/cmd/redirector/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"log"
 	"net/http"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleCloudPlatform/cloud-run-button
 go 1.14
 
 require (
-	cloud.google.com/go v0.55.0 // indirect
+	cloud.google.com/go v0.55.0
 	cloud.google.com/go/pubsub v1.3.1 // indirect
 	dmitri.shuralyov.com/gpu/mtl v0.0.0-20191203043605-d42048ed14fd // indirect
 	github.com/AlecAivazis/survey/v2 v2.0.7


### PR DESCRIPTION
In some cases such as G Suite requiring some users to be re-authed every N
hours, creds won't be present in the Cloud Shell. This patch adds a 2-minute
wait to the experience, with an indicator telling user to authenticate.

Internal bug: 154573156
cc: @jamesward