### PR TITLE
add pause period to readiness check

### DIFF
--- a/cmd/cloudshell_open/deploy.go
+++ b/cmd/cloudshell_open/deploy.go
@@ -184,6 +184,7 @@ func waitReady(project, name, region string) error {
 				}
 			}
 		}
+		time.Sleep(time.Second * 2)
 	}
 	return fmt.Errorf("the service did not become ready in %s, check Cloud Console for logs to see why it failed", wait)
 }


### PR DESCRIPTION
Currently we probably are hammering the api during the 4 minute period
non-stop as quick as the GetService returns. This might cause users to
potentially hit a rate limit error (causing run-button to fail itself).

So adding a 2 second time period to cool things down. Since it corresponds
to max 120 calls over 240 secs it should be ok for now.

cc: @jamesward