### PR TITLE
Note that create hooks are skipped on existing services

### DIFF
--- a/cmd/cloudshell_open/appfile.go
+++ b/cmd/cloudshell_open/appfile.go
@@ -46,11 +46,11 @@ type hook struct {
 }
 
 type buildpacks struct {
-	Builder	string `json:"builder"`
+	Builder string `json:"builder"`
 }
 
 type build struct {
-	Skip *bool `json:"skip"`
+	Skip       *bool      `json:"skip"`
 	Buildpacks buildpacks `json:"buildpacks"`
 }
 

--- a/cmd/cloudshell_open/deploy.go
+++ b/cmd/cloudshell_open/deploy.go
@@ -106,8 +106,8 @@ func newService(name, project, image string, envs map[string]string, options opt
 				Spec: &runapi.RevisionSpec{
 					Containers: []*runapi.Container{
 						{
-							Image: image,
-							Env:   envVars,
+							Image:     image,
+							Env:       envVars,
 							Resources: optionsToResourceRequirements(options),
 						},
 					},

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -354,7 +354,9 @@ func run(opts runOpts) error {
 		if err != nil {
 			return err
 		}
-	}
+	} else {
+        fmt.Println(infoPrefix + " Configured create hooks are skipped on existing services")
+    }
 
 	optionsFlags := optionsToFlags(appFile.Options)
 

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -355,8 +355,8 @@ func run(opts runOpts) error {
 			return err
 		}
 	} else {
-        fmt.Println(infoPrefix + " Configured create hooks are skipped on existing services")
-    }
+		fmt.Println(infoPrefix + " Configured create hooks are skipped on existing services")
+	}
 
 	optionsFlags := optionsToFlags(appFile.Options)
 


### PR DESCRIPTION
Without this change, pre/post create hooks are silently skipped. 

The message as it is will not make sense if there aren't any create hooks are configured, but it's better than nothing.