### PR TITLE
Expose deployed service URL to post-deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Reference:
     - `commands`: _(array of strings)_ The list of commands to run
   - `precreate`: _(optional)_ Runs the specified commands before the service has been created
     - `commands`: _(array of strings)_ The list of commands to run
-  - `postcreate`: _(optional)_ Runs the specified commands after the service has been created
+  - `postcreate`: _(optional)_ Runs the specified commands after the service has been created; the `SERVICE_URL` environment variable provides the URL of the deployed Cloud Run service
     - `commands`: _(array of strings)_ The list of commands to run
 
 ### Notes

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -405,6 +405,8 @@ func run(opts runOpts) error {
 		return err
 	}
 
+	hookEnvs = append(hookEnvs, fmt.Sprintf("SERVICE_URL=%s", url))
+
 	if existingService == nil {
 		err = runScripts(appDir, appFile.Hooks.PostCreate.Commands, hookEnvs)
 		if err != nil {


### PR DESCRIPTION
Introduce the `SERVICE_URL` environment variable passed to the `Post-Create` hook command, with the URL of the deployed Cloud Run service as value.