### PR TITLE
provide env ordering via "order" key

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ For example, a fully populated `app.json` file looks like this:
         },
         "APP_SECRET": {
             "generator": "secret"
+        },
+        "ORDERED_ENV": {
+            "description": "control the order env variables are prompted",
+            "order": 100
         }
     },
     "options": {
@@ -115,6 +119,9 @@ Reference:
   - `required`, _(optional, default: `true`)_ indicates if they user must provide
     a value for this variable.
   - `generator`, _(optional)_ use a generator for the value, currently only support `secret`
+  - `order`, _(optional)_ if specified, used to indicate the order in which the
+    variable is prompted to the user. If some variables specify this and some
+    don't, then the unspecified ones are prompted last.
 - `options`: _(optional)_ Options when deploying the service
   - `allow-unauthenticated`: _(optional, default: `true`)_ allow unauthenticated requests
   - `memory`: _(optional)_ memory for each instance

--- a/cmd/cloudshell_open/appfile_test.go
+++ b/cmd/cloudshell_open/appfile_test.go
@@ -233,3 +233,25 @@ func TestGetAppFile(t *testing.T) {
 		t.Fatalf("wrong parsed value: got=%#v, expected=%#v", v, expected)
 	}
 }
+
+func Test_sortedEnvs(t *testing.T) {
+	envs := map[string]env{
+		"NIL_ORDER": {},
+		"ORDER_100": {Order: mkInt(100)},
+		"ORDER_0":   {Order: mkInt(0)},
+		"ORDER_-10": {Order: mkInt(-10)},
+		"ORDER_50":  {Order: mkInt(50)},
+	}
+	got := sortedEnvs(envs)
+	expected := []string{
+		"ORDER_-10", "ORDER_0", "ORDER_50", "ORDER_100", "NIL_ORDER",
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("sorted envs in wrong order: expected:%v\ngot=%v", expected, got)
+	}
+}
+
+func mkInt(i int) *int {
+	return &i
+}


### PR DESCRIPTION
Introducing an optional "order" key to the env object.

The sorting takes a look at if "order" field is specified or not. If not,
the key is prompted last. If specified, it sorts them by the value of the
"order" field.

The order is still non-deterministic if env objects don't specify an
"order" value. (i.e. this patch still doesn't preserve map order).

Fixes #205.
cc: @jamesward 