### PR TITLE
add configuration for pack build - fixes #215

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ For example, a fully populated `app.json` file looks like this:
     "build": {
         "skip": false,
         "buildpacks": {
-            "builder": "some/builderimage"
+            "builder": "some/builderimage",
+            "env": [
+                "GOOGLE_BUILDABLE=myapp",
+                "GOOGLE_RUNTIME_VERSION=1.14.6"
+            ]
         }
     },
     "hooks": {
@@ -135,6 +139,7 @@ Reference:
  manually
   - `buildpacks`: _(optional)_ buildpacks config
     - `builder`: _(optional, default: `gcr.io/buildpacks/builder:v1`)_ overrides the buildpack builder image
+    - `env`: _(optional)_ environment variables that are set at build time
 - `hooks`: _(optional)_ Run commands in separate bash shells with the environment variables configured for the
   application and environment variables `GOOGLE_CLOUD_PROJECT` (Google Cloud project), `GOOGLE_CLOUD_REGION`
   (selected Google Cloud Region), `K_SERVICE` (Cloud Run service name), `IMAGE_URL` (container image URL), `APP_DIR`

--- a/cmd/cloudshell_open/appfile.go
+++ b/cmd/cloudshell_open/appfile.go
@@ -50,7 +50,8 @@ type hook struct {
 }
 
 type buildpacks struct {
-	Builder string `json:"builder"`
+	Builder string   `json:"builder"`
+	Env     []string `json:"env"`
 }
 
 type build struct {

--- a/cmd/cloudshell_open/appfile_test.go
+++ b/cmd/cloudshell_open/appfile_test.go
@@ -87,6 +87,42 @@ func Test_parseAppFile(t *testing.T) {
 		want    *appFile
 		wantErr bool
 	}{
+		{"buildpacks with env", `{
+			"build": {
+				"skip": false,
+				"buildpacks": {
+					"builder": "some/builderimage",
+					"env": [
+						"GOOGLE_ENTRYPOINT=\"gunicorn -p :8080 main:app\"",
+						"GOOGLE_BUILDABLE=myapp"
+					]
+				}
+			}}`, &appFile{
+			Build: build{
+				Skip: &fals,
+				Buildpacks: buildpacks{
+					Builder: "some/builderimage",
+					Env: []string{
+						`GOOGLE_ENTRYPOINT="gunicorn -p :8080 main:app"`,
+						"GOOGLE_BUILDABLE=myapp",
+					},
+				},
+			},
+		}, false},
+		{"buildbapck without env", `{
+			"build": {
+				"skip": false,
+				"buildpacks": {
+					"builder": "some/builderimage"
+				}
+			}}`, &appFile{
+			Build: build{
+				Skip: &fals,
+				Buildpacks: buildpacks{
+					Builder: "some/builderimage",
+				},
+			},
+		}, false},
 		{"empty json is EOF", ``, nil, true},
 		{"empty object ok", `{}`, &appFile{}, false},
 		{"bad object at root", `1`, nil, true},

--- a/cmd/cloudshell_open/pack.go
+++ b/cmd/cloudshell_open/pack.go
@@ -19,8 +19,12 @@ import (
 	"os/exec"
 )
 
-func packBuild(dir, image, builderImage string) error {
-	cmd := exec.Command("pack", "build", "--quiet", "--builder", builderImage, "--path", dir, image)
+func packBuild(dir, image, builderImage string, builderEnv []string) error {
+	args := []string{"build", image, "--quiet", "--builder", builderImage, "--path", dir}
+	if len(builderEnv) > 0 {
+		args = append(args, builderEnv...)
+	}
+	cmd := exec.Command("pack", args...)
 	b, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("pack build failed: %v, output:\n%s", err, string(b))


### PR DESCRIPTION
Add environment variables that are set at build time for build pack according to [GoogleCloudPlatform/buildpacks: Builders and buildpacks designed to run on Google Cloud's container platforms](https://github.com/GoogleCloudPlatform/buildpacks#configuration)