### PR TITLE
Add max-instances and concurrency options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ For example, a fully populated `app.json` file looks like this:
         "memory": "512Mi",
         "cpu": "1",
         "port": 80,
-        "http2": false
+        "http2": false,
+        "concurrency": 80,
+        "max-instances": 10
     },
     "build": {
         "skip": false,
@@ -129,6 +131,8 @@ Reference:
   - `port`: _(optional)_ if your application doesn't respect the PORT environment
     variable provided by Cloud Run, specify the port number it listens on
   - `http2`: _(optional)_ use http2 for the connection
+  - `concurrency`: _(optional)_ concurrent requests for each instance
+  - `max-instances`: _(optional)_ autoscaling limit (max 1000)
 - `build`: _(optional)_ Build configuration
   - `skip`: _(optional, default: `false`)_ skips the built-in build methods (`docker build`, `Maven Jib`, and
  `buildpacks`), but still allows for `prebuild` and `postbuild` hooks to be run in order to build the container image

--- a/cmd/cloudshell_open/appfile.go
+++ b/cmd/cloudshell_open/appfile.go
@@ -43,6 +43,8 @@ type options struct {
 	CPU                  string `json:"cpu"`
 	Port                 int    `json:"port"`
 	HTTP2                *bool  `json:"http2"`
+	Concurrency          int    `json:"concurrency"`
+	MaxInstances         int    `json:"max-instances"`
 }
 
 type hook struct {

--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -20,13 +20,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/GoogleCloudPlatform/cloud-run-button/cmd/instrumentless"
-	"google.golang.org/api/transport"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/GoogleCloudPlatform/cloud-run-button/cmd/instrumentless"
+	"google.golang.org/api/transport"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/briandowns/spinner"
@@ -494,6 +495,16 @@ func optionsToFlags(options options) []string {
 		} else {
 			flags = append(flags, "--use-http2")
 		}
+	}
+
+	if options.Concurrency > 0 {
+		concurrencySetting := fmt.Sprintf("--concurrency=%d", options.Concurrency)
+		flags = append(flags, concurrencySetting)
+	}
+
+	if options.MaxInstances > 0 {
+		maxInstancesSetting := fmt.Sprintf("--max-instances=%d", options.MaxInstances)
+		flags = append(flags, maxInstancesSetting)
 	}
 
 	return flags


### PR DESCRIPTION
Only adds options if defined by user (otherwise doesn't pass a default value, allowing downstream systems to specify)

Resolves #227

Addresses request in #108, but doesn't scale the solution as suggested.

Tested in isolation, pending automated testing