### PR TITLE
remove a TODO, --use-http2 is GA

### DIFF
--- a/cmd/cloudshell_open/main.go
+++ b/cmd/cloudshell_open/main.go
@@ -404,18 +404,11 @@ func run(opts runOpts) error {
 		}
 	}
 
-	deployCommand := "\tgcloud run deploy %s"
-
-	// TODO remove when --use-http2 graduates to GA
-	if appFile.Options.HTTP2 != nil && *appFile.Options.HTTP2 == true {
-		deployCommand = "\tgcloud beta run deploy %s"
-	}
-
 	optionsFlags := optionsToFlags(appFile.Options)
 
 	serviceLabel := highlight(serviceName)
 	fmt.Println(infoPrefix + " FYI, running the following command:")
-	cmdColor.Printf(deployCommand, parameter(serviceName))
+	cmdColor.Printf("\tgcloud run deploy %s", parameter(serviceName))
 	cmdColor.Println("\\")
 	cmdColor.Printf("\t  --project=%s", parameter(project))
 	cmdColor.Println("\\")


### PR DESCRIPTION
http2 is went GA on 2021-06-22
https://cloud.google.com/run/docs/release-notes#June_22_2021

Just to make sure, I've check gcloud version on Cloud Shell Editor, Google Cloud SDK is 386.0.0 and `gcloud run deploy --help` includes `--[no-]use-http2` option.