### PR TITLE
Improve debug capabilities

### DIFF
--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
 
       $TEST_CMD --description "no config" --directory empty-appjson --expected_text 'hello, world'
 
-      $TEST_CMD --description "inline hooks" --directory hooks-prepostcreate-inline --expected_text 'AB'
+      $TEST_CMD --description "inline hooks" --directory hooks-prepostcreate-inline --expected_text 'AB' --debug
 
       $TEST_CMD --description "external hooks" --directory hooks-prepostcreate-external --expected_text '3'
       $TEST_CMD --description "external hooks, dirty" --directory hooks-prepostcreate-external --expected_text '3' --dirty

--- a/integration.cloudbuild.yaml
+++ b/integration.cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
   - id: run tests
     name: gcr.io/$PROJECT_ID/button
     env:
+      - "DEBUG=${_DEBUG}"
       - "GOOGLE_CLOUD_PROJECT=$PROJECT_ID"
       - "GOOGLE_CLOUD_REGION=${_REGION}"
       - "GIT_BRANCH=${BRANCH_NAME}"
@@ -39,7 +40,7 @@ steps:
 
       $TEST_CMD --description "no config" --directory empty-appjson --expected_text 'hello, world'
 
-      $TEST_CMD --description "inline hooks" --directory hooks-prepostcreate-inline --expected_text 'AB' --debug
+      $TEST_CMD --description "inline hooks" --directory hooks-prepostcreate-inline --expected_text 'AB'
 
       $TEST_CMD --description "external hooks" --directory hooks-prepostcreate-external --expected_text '3'
       $TEST_CMD --description "external hooks, dirty" --directory hooks-prepostcreate-external --expected_text '3' --dirty
@@ -75,6 +76,7 @@ substitutions:
   _REGION: us-central1
   _REPO_URL: https://github.com/GoogleCloudPlatform/cloud-run-button
   _REPO_BRANCH: master
+  _DEBUG: ""
 
 options:
   machineType: "N1_HIGHCPU_32"

--- a/tests/run_integration_test.py
+++ b/tests/run_integration_test.py
@@ -158,6 +158,7 @@ def get_url(service_url, expected_status=200):
     debugging(f"Service: {service_url}")
 
     try:
+        request.urlcleanup() # reset cache
         resp = request.urlopen(service_url)
         status = resp.status
         body = resp.read().decode("utf-8")

--- a/tests/run_integration_test.py
+++ b/tests/run_integration_test.py
@@ -25,8 +25,8 @@ if not GOOGLE_CLOUD_REGION:
 
 WORKING_DIR = os.environ.get("WORKING_DIR", ".")
 
-DEBUG=os.environ.get("DEBUG", False)
-if DEBUG == "": 
+DEBUG = os.environ.get("DEBUG", False)
+if DEBUG == "":
     DEBUG = False
 
 ###############################################################################
@@ -86,10 +86,7 @@ def run_shell(params):
     output = resp.stdout.decode("utf-8")
     error = resp.stderr.decode("utf-8")
 
-    
     if DEBUG:
-        # Animated CLIs can make output messy, so only show the long tail
-        #debugging("stdout:", output[-300:] or "<None>")
         debugging("stdout:", output or "<None>")
         debugging("stderr:", error or "<None>")
 
@@ -183,6 +180,7 @@ def get_url(service_url, expected_status=200):
 def cli() -> None:
     """Tool for testing Cloud Run Button deployments"""
     pass
+
 
 @cli.command()
 @click.option("--description", help="Test description")

--- a/tests/run_integration_test.py
+++ b/tests/run_integration_test.py
@@ -25,13 +25,17 @@ if not GOOGLE_CLOUD_REGION:
 
 WORKING_DIR = os.environ.get("WORKING_DIR", ".")
 
+DEBUG=os.environ.get("DEBUG", False)
+if DEBUG == "": 
+    DEBUG = False
+
 ###############################################################################
 
 
 def debugging(*args):
     c = click.get_current_context()
     output = " ".join([str(k) for k in args])
-    if c.params["debug"]:
+    if DEBUG:
         print(f"🐞 {output}")
 
 
@@ -66,10 +70,10 @@ def cloudshell_open(directory, repo_url, git_branch):
 
     if directory:
         params += [f"--dir={TESTS_DIR}/{directory}"]
-    return run_shell(params, quiet=True)
+    return run_shell(params)
 
 
-def run_shell(params, quiet=False):
+def run_shell(params):
     """Invoke the given subproceess, capturing output status and returning stdout"""
     debugging("Running:", " ".join(params))
 
@@ -81,9 +85,12 @@ def run_shell(params, quiet=False):
 
     output = resp.stdout.decode("utf-8")
     error = resp.stderr.decode("utf-8")
-    # Animated CLIs can make output messy, so only show the long tail
-    if not quiet:
-        debugging("stdout:", output[-300:] or "<None>")
+
+    
+    if DEBUG:
+        # Animated CLIs can make output messy, so only show the long tail
+        #debugging("stdout:", output[-300:] or "<None>")
+        debugging("stdout:", output or "<None>")
         debugging("stderr:", error or "<None>")
 
     if resp.returncode != 0:
@@ -185,7 +192,6 @@ def cli() -> None:
 @click.option("--expected_status", default=200, help="Status code to expect")
 @click.option("--expected_text", help="Text in service to expect")
 @click.option("--dirty", is_flag=True, default=False, help="Keep existing service")
-@click.option("--debug", is_flag=True, default=False, help="Debuggening")
 def deploy(
     description,
     directory,
@@ -194,7 +200,6 @@ def deploy(
     expected_status,
     expected_text,
     dirty,
-    debug,
 ):
     """Run service tests.
 


### PR DESCRIPTION
* Make an environment variable turn on/off debugging for the entire job
* Remove truncation of CLI output (now days it's behaves a lot better in scripts, so the output is useful to have when debugging)
* Add [urlcleanup](https://docs.python.org/3/library/urllib.request.html#urllib.request.urlcleanup) to prevent potential caching issues. 