### PR TITLE
chore: batch renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:base",
+    "schedule:weekly",
+    ":semanticCommits"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "commitMessagePrefix": "chore(all): ",
+  "commitMessageAction": "update",
+  "groupName": "all",
+  "packageRules": [
+    {
+      "updateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
+  ],
+  "constraints": {
+    "go": "1.21"
+  }
 }


### PR DESCRIPTION
To prevent trickling renovate PRs (#278, #279, #281, #282, #283, #284, #286, #287, #288), use renovate config (borrowed from https://github.com/GoogleCloudPlatform/cloud-run-microservice-template-go to batch updates weekly.)